### PR TITLE
Added provider 'joker.com'

### DIFF
--- a/README
+++ b/README
@@ -64,6 +64,7 @@ SUPPORTED PROVIDERS:
 	enom.com
 	entrydns.net
 	freedns.afraid.org
+	joker.com
 	loopia.se
 	myonlineportal.net
 	namecheap.com

--- a/ddns.conf.sample
+++ b/ddns.conf.sample
@@ -90,6 +90,11 @@
 # provider = freedns.afraid.org
 # token = token
 
+# [test.joker.com]
+# provider = joker.com
+# username = user
+# password = pass
+
 # [test.google.com]
 # provider = domains.google.com
 # username = user

--- a/src/ddns/providers.py
+++ b/src/ddns/providers.py
@@ -1048,6 +1048,19 @@ class DDNSProviderFreeDNSAfraidOrg(DDNSProvider):
 		raise DDNSUpdateError
 
 
+class DDNSProviderJoker(DDNSProtocolDynDNS2, DDNSProvider):
+		handle  = "joker.com"
+		name    = "Joker.com Dynamic DNS"
+		website = "https://joker.com/"
+		protocols = ("ipv4",)
+
+		# Information about the request can be found here:
+		# https://joker.com/faq/content/11/427/en/what-is-dynamic-dns-dyndns.html
+		# Using DynDNS V2 protocol over HTTPS here
+
+		url = "https://svc.joker.com/nic/update"
+
+
 class DDNSProviderGoogle(DDNSProtocolDynDNS2, DDNSProvider):
         handle    = "domains.google.com"
         name      = "Google Domains"


### PR DESCRIPTION
Added "joker.com" as provider. DNS updates are submitted using the DynDNS 2 protocol over HTTPS.
Successfully tested with several domains.