### PR TITLE
Update Provider SPDNS

### DIFF
--- a/src/ddns/providers.py
+++ b/src/ddns/providers.py
@@ -1453,7 +1453,7 @@ class DDNSProviderSPDNS(DDNSProtocolDynDNS2, DDNSProvider):
 	# http://wiki.securepoint.de/index.php/SPDNS_FAQ
 	# http://wiki.securepoint.de/index.php/SPDNS_Update-Tokens
 
-	url = "https://update.spdns.de/nic/update"
+	url = "https://update.spdyn.de/nic/update"
 
 	@property
 	def username(self):


### PR DESCRIPTION
Getting a warning in spdns account that the new Server update.spdyn.de should be used.
