### PR TITLE
Update providers.py

### DIFF
--- a/src/ddns/providers.py
+++ b/src/ddns/providers.py
@@ -536,7 +536,7 @@ class DDNSProviderBindNsupdate(DDNSProvider):
 
 			logger.debug("  %s" % line)
 
-		return "\n".join(scriptlet)
+		return "\n".join(scriptlet).encode()
 
 
 class DDNSProviderChangeIP(DDNSProvider):


### PR DESCRIPTION
Python 3 memoryview requires an encoded string.

without this change, attempting a ddns update with nsupdate would throw this message:

Dynamic DNS update for example.com (BIND nsupdate utility) threw an unhandled exception: Traceback (most recent call last):   File "/usr/lib/python3.8/site-packages/ddns/__init__.py", line 164, in _update     entry(force=force)   File "/usr/lib/python3.8/site-packages/ddns/providers.py", line 158, in __call__     self.update()   File "/usr/lib/python3.8/site-packages/ddns/providers.py", line 489, in update     stdout, stderr = p.communicate(scriptlet)   File "/usr/lib/python3.8/subprocess.py", line 1024, in communicate     stdout, stderr = self._communicate(input, endtime, timeout)   File "/usr/lib/python3.8/subprocess.py", line 1846, in _communicate     input_view = memoryview(self._input) TypeError: memoryview: a bytes-like object is required, not 'str'