### PR TITLE
desec.io update function updated to fix ddns update failing

### DIFF
--- a/src/ddns/providers.py
+++ b/src/ddns/providers.py
@@ -604,7 +604,9 @@ class DDNSProviderDesecIO(DDNSProtocolDynDNS2, DDNSProvider):
 	# desec.io sends the IPv6 and IPv4 address in one request
 
 	def update(self):
-		data = DDNSProtocolDynDNS2.prepare_request_data(self, "ipv4")
+		data = {
+			"myip"     : self.get_address("ipv4")
+		}
 
 		# This one supports IPv6
 		myipv6 = self.get_address("ipv6")


### PR DESCRIPTION
Desec.io ddns update didn't go through as the API does not recognize hostname as a query param. Updated to remove hostname from the query.